### PR TITLE
Use `nodenv init -` to setup nodenv

### DIFF
--- a/zsh-nodenv.plugin.zsh
+++ b/zsh-nodenv.plugin.zsh
@@ -1,26 +1,3 @@
-GITHUB="https://github.com"
-
-[[ -z "$NODENV_HOME" ]] && export NODENV_HOME="$HOME/.nodenv"
-
-_zsh_nodenv_install() {
-    echo "Installing nodenv..."
-    git clone "${GITHUB}/nodenv/nodenv.git"            "${NODENV_HOME}"
-    git clone "${GITHUB}/nodenv/nodenv-update.git"     "${NODENV_HOME}/plugins/nodenv-update"
-    git clone "${GITHUB}/nodenv/node-build.git"        "${NODENV_HOME}/plugins/nodenv-build"
-}
-
-_zsh_nodenv_load() {
-    # export PATH
-    export PATH="$NODENV_HOME/bin:$PATH"
-
-    eval "$(nodenv init - zsh)"
-}
-
-# install nodenv if it isnt already installed
-[[ ! -f "$NODENV_HOME/libexec/nodenv" ]] && _zsh_nodenv_install
-
-# load nodenv if it is installed
-if [[ -f "$NODENV_HOME/libexec/nodenv" ]]; then
-    _zsh_nodenv_load
+if test -d $HOME/.nodenv; then
+    eval "$(nodenv init -)"
 fi
-


### PR DESCRIPTION
Currently this plugin doesn't work on my machine. `nodenv/libexec` is not something that my nodenv creates.